### PR TITLE
Migrated to nbdev3

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include settings.ini
 include CONTRIBUTING.md
 include LICENSE
 include README.md

--- a/fastai/text/core.py
+++ b/fastai/text/core.py
@@ -420,7 +420,7 @@ class SentencePieceTokenizer(): #TODO: pass the special tokens symbol to sp
 SentencePieceTokenizer.sp_vocab = SentencePieceTokenizer.vocab
 SubwordTokenizer = SentencePieceTokenizer
 
-# %% ../../nbs/30_text.core.ipynb #3e729d00
+# %% ../../nbs/30_text.core.ipynb #e234e4ed
 class HFTokenizer:
     "HuggingFace tokenizers wrapper mimicking SentencePieceTokenizer API"
     def __init__(self, pretrained, output_ids=True, special_toks=None):

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -530,7 +530,7 @@ class Chunks:
 
     def __len__(self): return self.totlen
 
-# %% ../nbs/00_torch_core.ipynb #e82135c4
+# %% ../nbs/00_torch_core.ipynb #07849b81
 class ReversedChunks(Chunks):
     "Slice and int indexing into a list of lists but in reverse"
     def __init__(self, chunks, lens=None):

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -7827,6 +7827,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "32aea426",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7847,6 +7848,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0ded68cd",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/nbs/30_text.core.ipynb
+++ b/nbs/30_text.core.ipynb
@@ -1712,6 +1712,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d1cd87a9",
    "metadata": {},
    "outputs": [
     {
@@ -1861,6 +1862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ad6252f8",
    "metadata": {},
    "outputs": [
     {
@@ -2021,6 +2023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e4bc3ed9",
    "metadata": {},
    "outputs": [
     {
@@ -2126,6 +2129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4534e6de",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2133,6 +2137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0117e12e",
    "metadata": {},
    "outputs": [
     {
@@ -2153,6 +2158,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ee0b2707",
    "metadata": {},
    "source": [
     "### Tokenizer by huggingface"
@@ -2161,6 +2167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "73578c59",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2168,6 +2175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5dd4df51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2197,6 +2205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9789c0f1",
    "metadata": {},
    "outputs": [
     {
@@ -2218,6 +2227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "eb18db51",
    "metadata": {},
    "outputs": [
     {
@@ -2238,6 +2248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4273d579",
    "metadata": {},
    "outputs": [
     {
@@ -2345,6 +2356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "99496a4d",
    "metadata": {},
    "outputs": [
     {
@@ -2486,6 +2498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e5eb63bb",
    "metadata": {},
    "outputs": [
     {
@@ -2515,6 +2528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "089a5075",
    "metadata": {},
    "outputs": [
     {
@@ -2634,6 +2648,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "16b62135",
    "metadata": {},
    "outputs": [
     {

--- a/nbs/31_text.data.ipynb
+++ b/nbs/31_text.data.ipynb
@@ -326,6 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "197f97f6",
    "metadata": {},
    "outputs": [
     {
@@ -432,6 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "75d93b6c",
    "metadata": {},
    "outputs": [
     {
@@ -832,6 +834,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "064a26c4",
    "metadata": {},
    "outputs": [
     {
@@ -931,6 +934,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bddbc479",
    "metadata": {},
    "outputs": [
     {
@@ -1064,6 +1068,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d9e51df4",
    "metadata": {},
    "source": [
     "Function `pad_chunk` pads the sequence `x` to reach `pad_len` or the nearest greater-or-equal multiple of `seq_len`.\n",
@@ -1127,6 +1132,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "47034d55",
    "metadata": {},
    "source": [
     "The difference with the base `pad_input` is that most of the padding is applied first (if `pad_first=True`) or at the end (if `pad_first=False`) but only by a round multiple of `seq_len`. The rest of the padding is applied to the end (or the beginning if `pad_first=False`). This is to work with `SequenceEncoder` with recurrent models."
@@ -1291,6 +1297,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "95c73bcb",
    "metadata": {},
    "source": [
     "Support for backward"
@@ -1299,6 +1306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "02a4c51d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2261,6 +2269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "07a5d079",
    "metadata": {},
    "outputs": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ configure_accelerate = "fastai.distributed:configure_accelerate"
 version = {attr = "fastai.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["fastai"]
+include = ["fastai", "fastai.*"]
 
 [tool.nbdev]
 allowed_metadata_keys = ['solveit']

--- a/test_settings.ini
+++ b/test_settings.ini
@@ -1,11 +1,1 @@
-[DEFAULT]
-lib_name = fastai
-user = fastai
-branch = master
-git_url = https://github.com/%(user)s/%(lib_name)s/tree/%(branch)s/
-lib_path = %(lib_name)s
-nbs_path = nbs
-doc_path = docs
-tst_flags = tst
-version = 0.0.1
 


### PR DESCRIPTION
Hey Piotr, install from github did not work for me. It missed `fastai.data` for example.  I've fixed it so we can install directly from github instead of requiring `pip install .`.